### PR TITLE
Fix animate-in elements remaining hidden in React build

### DIFF
--- a/frontend-react/src/App.jsx
+++ b/frontend-react/src/App.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Navbar from "./components/Navbar";
 import Hero from "./components/Hero";
 import Services from "./components/Services";
@@ -8,9 +8,37 @@ import Contact from "./components/Contact";
 import Footer from "./components/Footer";
 
 function App() {
-	return (
-		<>
-			<Navbar />
+        useEffect(() => {
+                const observerOptions = {
+                        root: null,
+                        rootMargin: "0px",
+                        threshold: 0.1,
+                };
+
+                const observerCallback = (entries, observer) => {
+                        entries.forEach((entry) => {
+                                if (entry.isIntersecting) {
+                                        entry.target.classList.add("fade-in");
+                                        observer.unobserve(entry.target);
+                                }
+                        });
+                };
+
+                const observer = new IntersectionObserver(
+                        observerCallback,
+                        observerOptions
+                );
+
+                document
+                        .querySelectorAll(".animate-in")
+                        .forEach((element) => observer.observe(element));
+
+                return () => observer.disconnect();
+        }, []);
+
+        return (
+                <>
+                        <Navbar />
 			<Hero />
 			<Services />
 			<Portfolio />


### PR DESCRIPTION
## Summary
- ensure `.animate-in` elements fade in when they enter the viewport for the React frontend

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e65869044832a8b7f133f7d3ffdca