### PR TITLE
Organize asset output for React build

### DIFF
--- a/frontend-react/package-lock.json
+++ b/frontend-react/package-lock.json
@@ -16,7 +16,8 @@
 				"autoprefixer": "^10.4.12",
 				"postcss": "^8.4.18",
 				"tailwindcss": "^3.2.4",
-				"vite": "^7.0.6"
+				"vite": "^7.0.6",
+				"vite-plugin-static-copy": "^3.1.1"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -1727,6 +1728,21 @@
 				"url": "https://github.com/sponsors/rawify"
 			}
 		},
+		"node_modules/fs-extra": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1795,6 +1811,13 @@
 			"engines": {
 				"node": ">=10.13.0"
 			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
@@ -1944,6 +1967,19 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -2121,6 +2157,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/p-map": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+			"integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/package-json-from-dist": {
@@ -2867,6 +2916,16 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -2978,6 +3037,26 @@
 				"yaml": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vite-plugin-static-copy": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.1.1.tgz",
+			"integrity": "sha512-oR53SkL5cX4KT1t18E/xU50vJDo0N8oaHza4EMk0Fm+2/u6nQivxavOfrDk3udWj+dizRizB/QnBvJOOQrTTAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^3.6.0",
+				"fs-extra": "^11.3.0",
+				"p-map": "^7.0.3",
+				"picocolors": "^1.1.1",
+				"tinyglobby": "^0.2.14"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"peerDependencies": {
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
 			}
 		},
 		"node_modules/vite/node_modules/fdir": {

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -16,6 +16,7 @@
 		"autoprefixer": "^10.4.12",
 		"postcss": "^8.4.18",
 		"tailwindcss": "^3.2.4",
-		"vite": "^7.0.6"
+		"vite": "^7.0.6",
+		"vite-plugin-static-copy": "^3.1.1"
 	}
 }

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -8,9 +8,9 @@
 /* noto sans */
 @font-face {
 	font-family: "Noto Sans";
-	src: url("./assets/fonts/noto-sans/notosans-regular-webfont.woff2")
+	src: url("/assets/fonts/noto-sans/notosans-regular-webfont.woff2")
 			format("woff2"),
-		url("./assets/fonts/noto-sans/notosans-regular-webfont.woff")
+		url("/assets/fonts/noto-sans/notosans-regular-webfont.woff")
 			format("woff");
 	font-weight: normal;
 	font-style: normal;
@@ -19,9 +19,9 @@
 
 @font-face {
 	font-family: "Noto Sans";
-	src: url("./assets/fonts/noto-sans/notosans-bold-webfont.woff2")
+	src: url("/assets/fonts/noto-sans/notosans-bold-webfont.woff2")
 			format("woff2"),
-		url("./assets/fonts/noto-sans/notosans-bold-webfont.woff")
+		url("/assets/fonts/noto-sans/notosans-bold-webfont.woff")
 			format("woff");
 	font-weight: bold;
 	font-style: normal;
@@ -30,9 +30,9 @@
 
 @font-face {
 	font-family: "Noto Sans";
-	src: url("./assets/fonts/noto-sans/notosans-italic-webfont.woff2")
+	src: url("/assets/fonts/noto-sans/notosans-italic-webfont.woff2")
 			format("woff2"),
-		url("./assets/fonts/noto-sans/notosans-italic-webfont.woff")
+		url("/assets/fonts/noto-sans/notosans-italic-webfont.woff")
 			format("woff");
 	font-weight: normal;
 	font-style: italic;
@@ -41,9 +41,9 @@
 
 @font-face {
 	font-family: "Noto Sans";
-	src: url("./assets/fonts/noto-sans/notosans-light-webfont.woff2")
+	src: url("/assets/fonts/noto-sans/notosans-light-webfont.woff2")
 			format("woff2"),
-		url("./assets/fonts/noto-sans/notosans-light-webfont.woff")
+		url("/assets/fonts/noto-sans/notosans-light-webfont.woff")
 			format("woff");
 	font-weight: 300;
 	font-style: normal;
@@ -52,9 +52,9 @@
 
 @font-face {
 	font-family: "Noto Sans";
-	src: url("./assets/fonts/noto-sans/notosans-semibold-webfont.woff2")
+	src: url("/assets/fonts/noto-sans/notosans-semibold-webfont.woff2")
 			format("woff2"),
-		url("./assets/fonts/noto-sans/notosans-semibold-webfont.woff")
+		url("/assets/fonts/noto-sans/notosans-semibold-webfont.woff")
 			format("woff");
 	font-weight: 600;
 	font-style: normal;
@@ -64,9 +64,9 @@
 /* josefin slab */
 @font-face {
 	font-family: "Josefin Slab";
-	src: url("./assets/fonts/josefin-slab/JosefinSlab-Regular.woff2")
+	src: url("/assets/fonts/josefin-slab/JosefinSlab-Regular.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-slab/JosefinSlab-Regular.woff")
+		url("/assets/fonts/josefin-slab/JosefinSlab-Regular.woff")
 			format("woff");
 	font-weight: normal;
 	font-style: normal;
@@ -75,9 +75,9 @@
 
 @font-face {
 	font-family: "Josefin Slab";
-	src: url("./assets/fonts/josefin-slab/JosefinSlab-SemiBold.woff2")
+	src: url("/assets/fonts/josefin-slab/JosefinSlab-SemiBold.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-slab/JosefinSlab-SemiBold.woff")
+		url("/assets/fonts/josefin-slab/JosefinSlab-SemiBold.woff")
 			format("woff");
 	font-weight: 600;
 	font-style: normal;
@@ -86,9 +86,9 @@
 
 @font-face {
 	font-family: "Josefin Slab";
-	src: url("./assets/fonts/josefin-slab/JosefinSlab-Bold.woff2")
+	src: url("/assets/fonts/josefin-slab/JosefinSlab-Bold.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-slab/JosefinSlab-Bold.woff") format("woff");
+		url("/assets/fonts/josefin-slab/JosefinSlab-Bold.woff") format("woff");
 	font-weight: bold;
 	font-style: normal;
 	font-display: swap;
@@ -96,9 +96,9 @@
 
 @font-face {
 	font-family: "Josefin Slab";
-	src: url("./assets/fonts/josefin-slab/JosefinSlab-BoldItalic.woff2")
+	src: url("/assets/fonts/josefin-slab/JosefinSlab-BoldItalic.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-slab/JosefinSlab-BoldItalic.woff")
+		url("/assets/fonts/josefin-slab/JosefinSlab-BoldItalic.woff")
 			format("woff");
 	font-weight: bold;
 	font-style: italic;
@@ -107,9 +107,9 @@
 
 @font-face {
 	font-family: "Josefin Slab";
-	src: url("./assets/fonts/josefin-slab/JosefinSlab-Light.woff2")
+	src: url("/assets/fonts/josefin-slab/JosefinSlab-Light.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-slab/JosefinSlab-Light.woff") format("woff");
+		url("/assets/fonts/josefin-slab/JosefinSlab-Light.woff") format("woff");
 	font-weight: 300;
 	font-style: normal;
 	font-display: swap;
@@ -117,9 +117,9 @@
 
 @font-face {
 	font-family: "Josefin Slab";
-	src: url("./assets/fonts/josefin-slab/JosefinSlab-Italic.woff2")
+	src: url("/assets/fonts/josefin-slab/JosefinSlab-Italic.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-slab/JosefinSlab-Italic.woff")
+		url("/assets/fonts/josefin-slab/JosefinSlab-Italic.woff")
 			format("woff");
 	font-weight: normal;
 	font-style: italic;
@@ -129,9 +129,9 @@
 /* josefin sans */
 @font-face {
 	font-family: "Josefin Sans";
-	src: url("./assets/fonts/josefin-sans/JosefinSans-Bold.woff2")
+	src: url("/assets/fonts/josefin-sans/JosefinSans-Bold.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-sans/JosefinSans-Bold.woff") format("woff");
+		url("/assets/fonts/josefin-sans/JosefinSans-Bold.woff") format("woff");
 	font-weight: bold;
 	font-style: normal;
 	font-display: swap;
@@ -139,9 +139,9 @@
 
 @font-face {
 	font-family: "Josefin Sans";
-	src: url("./assets/fonts/josefin-sans/JosefinSans-BoldItalic.woff2")
+	src: url("/assets/fonts/josefin-sans/JosefinSans-BoldItalic.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-sans/JosefinSans-BoldItalic.woff")
+		url("/assets/fonts/josefin-sans/JosefinSans-BoldItalic.woff")
 			format("woff");
 	font-weight: bold;
 	font-style: italic;
@@ -150,9 +150,9 @@
 
 @font-face {
 	font-family: "Josefin Sans";
-	src: url("./assets/fonts/josefin-sans/JosefinSans-Italic.woff2")
+	src: url("/assets/fonts/josefin-sans/JosefinSans-Italic.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-sans/JosefinSans-Italic.woff")
+		url("/assets/fonts/josefin-sans/JosefinSans-Italic.woff")
 			format("woff");
 	font-weight: normal;
 	font-style: italic;
@@ -161,9 +161,9 @@
 
 @font-face {
 	font-family: "Josefin Sans";
-	src: url("./assets/fonts/josefin-sans/JosefinSans-Regular.woff2")
+	src: url("/assets/fonts/josefin-sans/JosefinSans-Regular.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-sans/JosefinSans-Regular.woff")
+		url("/assets/fonts/josefin-sans/JosefinSans-Regular.woff")
 			format("woff");
 	font-weight: normal;
 	font-style: normal;
@@ -172,9 +172,9 @@
 
 @font-face {
 	font-family: "Josefin Sans";
-	src: url("./assets/fonts/josefin-sans/JosefinSans-Light.woff2")
+	src: url("/assets/fonts/josefin-sans/JosefinSans-Light.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-sans/JosefinSans-Light.woff") format("woff");
+		url("/assets/fonts/josefin-sans/JosefinSans-Light.woff") format("woff");
 	font-weight: 300;
 	font-style: normal;
 	font-display: swap;
@@ -182,9 +182,9 @@
 
 @font-face {
 	font-family: "Josefin Sans";
-	src: url("./assets/fonts/josefin-sans/JosefinSans-SemiBold.woff2")
+	src: url("/assets/fonts/josefin-sans/JosefinSans-SemiBold.woff2")
 			format("woff2"),
-		url("./assets/fonts/josefin-sans/JosefinSans-SemiBold.woff")
+		url("/assets/fonts/josefin-sans/JosefinSans-SemiBold.woff")
 			format("woff");
 	font-weight: 600;
 	font-style: normal;

--- a/frontend-react/vite.config.js
+++ b/frontend-react/vite.config.js
@@ -1,9 +1,37 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { viteStaticCopy } from "vite-plugin-static-copy";
+import path from "path";
 
 export default defineConfig({
-	plugins: [react()],
-	server: {
-		open: true,
-	},
+        plugins: [
+                react(),
+                viteStaticCopy({
+                        targets: [
+                                { src: "src/assets/fonts", dest: "assets" },
+                                { src: "src/assets/icons", dest: "assets" },
+                                { src: "src/assets/images", dest: "assets" },
+                        ],
+                }),
+        ],
+        server: {
+                open: true,
+        },
+        build: {
+                rollupOptions: {
+                        output: {
+                                assetFileNames: (assetInfo) => {
+                                        const ext = path
+                                                .extname(assetInfo.name || "")
+                                                .toLowerCase();
+                                        if (ext === ".css") {
+                                                return "css/[name]-[hash][extname]";
+                                        }
+                                        return "assets/[name]-[hash][extname]";
+                                },
+                                chunkFileNames: "js/[name]-[hash].js",
+                                entryFileNames: "js/[name]-[hash].js",
+                        },
+                },
+        },
 });


### PR DESCRIPTION
## Summary
- ensure fonts, icons, and images directories are copied to dist
- output generated CSS and JS to dedicated `css` and `js` folders
- switch font URLs to root-relative paths

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f01f3ac40832a973f96d821aad179