### PR TITLE
Fix gallery images not covering card container

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -389,11 +389,15 @@ a:hover .arrow {
 }
 
 .apply-gallery-card .content {
-	@apply relative overflow-hidden cursor-pointer h-64 w-full;
+        @apply relative overflow-hidden cursor-pointer h-64 w-full;
+}
+
+.apply-gallery-card .content button {
+        @apply block w-full h-full;
 }
 
 .apply-gallery-card .content img {
-	@apply block w-full h-full object-cover transform duration-500 grayscale hover:scale-110;
+        @apply block w-full h-full object-cover transform duration-500 grayscale hover:scale-110;
 }
 
 .apply-gallery-card .content:hover .caption,


### PR DESCRIPTION
## Summary
- ensure gallery card buttons expand to full size so images fill the card

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68903f40c534832abc13b372d9bea099