### PR TITLE
Add components section with sidebar navigation

### DIFF
--- a/frontend-11ty/src/components/alerts.md
+++ b/frontend-11ty/src/components/alerts.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Alert Components"
+meta_description: "TailwindCSS alert components"
+page_title: "Alerts"
+---
+
+## Alerts
+
+Content coming soon.

--- a/frontend-11ty/src/components/buttons.md
+++ b/frontend-11ty/src/components/buttons.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Button Components"
+meta_description: "TailwindCSS button components"
+page_title: "Buttons"
+---
+
+## Buttons
+
+Content coming soon.

--- a/frontend-11ty/src/components/cards.md
+++ b/frontend-11ty/src/components/cards.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Card Components"
+meta_description: "TailwindCSS card components"
+page_title: "Cards"
+---
+
+## Cards
+
+Content coming soon.

--- a/frontend-11ty/src/components/forms.md
+++ b/frontend-11ty/src/components/forms.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Form Components"
+meta_description: "TailwindCSS form components"
+page_title: "Forms"
+---
+
+## Forms
+
+Content coming soon.

--- a/frontend-11ty/src/components/image-gallery.md
+++ b/frontend-11ty/src/components/image-gallery.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Image Gallery Components"
+meta_description: "TailwindCSS image gallery components"
+page_title: "Image Gallery"
+---
+
+## Image Gallery
+
+Content coming soon.

--- a/frontend-11ty/src/components/index.md
+++ b/frontend-11ty/src/components/index.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Components"
+meta_description: "Library of UI components"
+page_title: "Components"
+---
+
+## Components
+
+Select a component from the sidebar.

--- a/frontend-11ty/src/components/login-form.md
+++ b/frontend-11ty/src/components/login-form.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Login Form Components"
+meta_description: "TailwindCSS login form components"
+page_title: "Login Form"
+---
+
+## Login Form
+
+Content coming soon.

--- a/frontend-11ty/src/components/modals.md
+++ b/frontend-11ty/src/components/modals.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Modal Components"
+meta_description: "TailwindCSS modal components"
+page_title: "Modals"
+---
+
+## Modals
+
+Content coming soon.

--- a/frontend-11ty/src/components/team-sections.md
+++ b/frontend-11ty/src/components/team-sections.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Team Section Components"
+meta_description: "TailwindCSS team section components"
+page_title: "Team Sections"
+---
+
+## Team Sections
+
+Content coming soon.

--- a/frontend-11ty/src/components/testimonials.md
+++ b/frontend-11ty/src/components/testimonials.md
@@ -1,0 +1,10 @@
+---
+layout: "layouts/components.njk"
+meta_title: "Testimonial Components"
+meta_description: "TailwindCSS testimonial components"
+page_title: "Testimonials"
+---
+
+## Testimonials
+
+Content coming soon.

--- a/frontend-11ty/src/includes/base.njk
+++ b/frontend-11ty/src/includes/base.njk
@@ -13,27 +13,27 @@
 		<link rel="canonical" href="{{ canonical }}" />
 		{% endif %}
 
-		<!-- css -->
-		<link rel="stylesheet" href="./assets/css/style.css" />
+                <!-- css -->
+                <link rel="stylesheet" href="/assets/css/style.css" />
 
-		<!-- js -->
-		<script src="./assets/js/main.js"></script>
+                <!-- js -->
+                <script src="/assets/js/main.js"></script>
 
-		<!-- favicons -->
-		<link
-			rel="apple-touch-icon"
-			sizes="180x180"
-			href="./assets/brand/apple-touch-icon.png" />
-		<link
-			rel="icon"
-			type="image/png"
-			sizes="32x32"
-			href="./assets/brand/favicon-32x32.png" />
-		<link
-			rel="icon"
-			type="image/png"
-			sizes="16x16"
-			href="./assets/brand/favicon-16x16.png" />
+                <!-- favicons -->
+                <link
+                        rel="apple-touch-icon"
+                        sizes="180x180"
+                        href="/assets/brand/apple-touch-icon.png" />
+                <link
+                        rel="icon"
+                        type="image/png"
+                        sizes="32x32"
+                        href="/assets/brand/favicon-32x32.png" />
+                <link
+                        rel="icon"
+                        type="image/png"
+                        sizes="16x16"
+                        href="/assets/brand/favicon-16x16.png" />
 	</head>
 
 	<body class="min-h-screen grid apply-bg-primary">

--- a/frontend-11ty/src/includes/layouts/components.njk
+++ b/frontend-11ty/src/includes/layouts/components.njk
@@ -1,0 +1,22 @@
+{% extends "base.njk" %}
+
+{% block content %}
+<main id="components" class="flex">
+  <aside class="w-64 p-6 border-r border-gray-200 dark:border-gray-700">
+    <nav class="space-y-2">
+      <a href="/components/alerts/" class="block">Alerts</a>
+      <a href="/components/buttons/" class="block">Buttons</a>
+      <a href="/components/cards/" class="block">Cards</a>
+      <a href="/components/forms/" class="block">Forms</a>
+      <a href="/components/image-gallery/" class="block">Image Gallery</a>
+      <a href="/components/login-form/" class="block">Login Form</a>
+      <a href="/components/modals/" class="block">Modals</a>
+      <a href="/components/team-sections/" class="block">Team Sections</a>
+      <a href="/components/testimonials/" class="block">Testimonials</a>
+    </nav>
+  </aside>
+  <section class="flex-1 p-6">
+    {{ content | safe }}
+  </section>
+</main>
+{% endblock content %}

--- a/frontend-11ty/src/includes/partials/navbar.njk
+++ b/frontend-11ty/src/includes/partials/navbar.njk
@@ -8,9 +8,10 @@
 			</div>
 			<nav class="desktop-menu">
 				<a href="#services" class="nav-link">What We Do</a>
-				<a href="#portfolio" class="nav-link">Our Work</a>
-				<a href="#team" class="nav-link">Our Team</a>
-				<a href="#contact" class="nav-link">Contact</a>
+                                <a href="#portfolio" class="nav-link">Our Work</a>
+                                <a href="#team" class="nav-link">Our Team</a>
+                                <a href="/components/alerts/" class="nav-link">Components</a>
+                                <a href="#contact" class="nav-link">Contact</a>
 			</nav>
 			<div class="desktop-controls">
 				<!-- theme / dark mode toggle button for desktop -->
@@ -137,9 +138,10 @@
 			<div class="mobile-nav-links">
 				<a href="#hero" class="mobile-nav-link">Home</a>
 				<a href="#services" class="mobile-nav-link">What We Do</a>
-				<a href="#portfolio" class="mobile-nav-link">Our Work</a>
-				<a href="#team" class="mobile-nav-link">Our Team</a>
-				<a href="#contact" class="mobile-nav-link">Contact</a>
+                                <a href="#portfolio" class="mobile-nav-link">Our Work</a>
+                                <a href="#team" class="mobile-nav-link">Our Team</a>
+                                <a href="/components/alerts/" class="mobile-nav-link">Components</a>
+                                <a href="#contact" class="mobile-nav-link">Contact</a>
 			</div>
 		</nav>
 	</div>


### PR DESCRIPTION
## Summary
- add Components link to desktop and mobile navigation
- create layout with left sidebar for component pages
- scaffold initial component pages (Alerts, Buttons, Cards, Forms, Image Gallery, Login Form, Modals, Team Sections, Testimonials)
- fix base layout asset paths for subpages

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689977eac694832ab24aa2a5cb88da0f